### PR TITLE
Enforces PRs to main from development branch only

### DIFF
--- a/.github/workflows/mergeToMain.yml
+++ b/.github/workflows/mergeToMain.yml
@@ -1,0 +1,17 @@
+name: Enforce PR from Development Only
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if source branch is not 'development'
+        run: |
+          if [ "${{ github.head_ref }}" != "development" ]; then
+            echo "❌ You can only create PRs to main from development"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a GitHub Actions workflow to restrict pull requests to the main branch, allowing only those originating from the development branch. This ensures a controlled and consistent branching strategy.