### PR TITLE
Fixed volume mounting for ollama-models folder

### DIFF
--- a/backend/llm_manager.py
+++ b/backend/llm_manager.py
@@ -8,7 +8,9 @@ from typing import Dict
 import socket
 
 OLLAMA_IMAGE = "ollama/ollama"
-OLLAMA_MODELS_VOLUME = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ollama-models")
+OLLAMA_MODELS_VOLUME = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "ollama-models"
+)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ALLOWED_MODELS = "allowed_models.json"
 

--- a/backend/llm_manager.py
+++ b/backend/llm_manager.py
@@ -8,7 +8,7 @@ from typing import Dict
 import socket
 
 OLLAMA_IMAGE = "ollama/ollama"
-OLLAMA_MODELS_VOLUME = os.path.abspath("./ollama-models")
+OLLAMA_MODELS_VOLUME = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ollama-models")
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ALLOWED_MODELS = "allowed_models.json"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,11 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./backend/ollama-models:/app/backend/ollama-models
+      - type: bind
+        source: ./backend/ollama-models
+        target: /app/backend/ollama-models
+        bind:
+          create_host_path: true
     environment:
       - IN_DOCKER=true
     networks:


### PR DESCRIPTION
### Summary  
This PR **fixes model persistence between sessions** by correcting volume mounting and ensuring models are properly cached.  

---

### Key Changes  

1. **Volume Mounting Configuration**  
   - Fixed incorrect relative paths by using absolute paths for the `ollama-models` directory.  
   - Implemented proper bind mounts in `docker-compose.yml` with `create_host_path: true`.  

2. **Model Caching**  
   - Models are now stored in the `ollama-models` folder between sessions.  
   - Eliminates redundant downloads for already cached models.  

3. **Automated Folder Creation**  
   - Ensures the `ollama-models` directory is created automatically if missing.  
   - Handled via Docker bind mount configuration.  

---

🚀 Ready for review!
